### PR TITLE
When clicked `Max safe borrow`, round the amount of R and limit to 2 …

### DIFF
--- a/src/components/OpenPosition/OpenPosition.tsx
+++ b/src/components/OpenPosition/OpenPosition.tsx
@@ -337,7 +337,7 @@ const OpenPosition = () => {
         const defaultBorrowAmount = selectedCollateralTokenBalanceValues.value
           .div(borrowTokenPrice)
           .div(HEALTHY_RATIO + HEALTHY_RATIO_BUFFER)
-          .toString();
+          .toRounded(2);
         setBorrowAmount(defaultBorrowAmount);
       }
     }


### PR DESCRIPTION
…decimals